### PR TITLE
point CFP_link direct to dchhv.org

### DIFF
--- a/config_tmpl.py
+++ b/config_tmpl.py
@@ -12,8 +12,6 @@ DC_num="";  # DEF CON number, used to make things cleaner and specific year to y
 DC_days="";  # DEF CON event days, used to note the days of the con
 DC_floormapurl="";  # URL pointing to the DEF CON floormap, speakers should know where they are going
 
-CFP_link=""; # URL pointing to the DCHHV CFP form
-
 Badge_meet="";  # Meeting time and location to give speakers their badges
 
 Response_deadline="";  # Deadline for CFP applicants to respond to confirm their presentation

--- a/guest_send_invitation_email.py
+++ b/guest_send_invitation_email.py
@@ -22,7 +22,7 @@ with open(sys.argv[1], 'r') as csvfile:
   for row in csvlines:
     if row['Blacklist'].lower() == "n":
       response = invite_tmpl.substitute(Name=row['Name'].split(' ')[0],
-        CFP_link=config.CFP_link);
+        CFP_link='https://dchhv.org/CFP.html');
     elif row['Blacklist'].lower() == "y":
       print "Skipping \'%s\' as they have been removed from the active contact list!" % row['Name'];
       raise SystemExit


### PR DESCRIPTION
if we're not going to link to a changing google form then the CFP_link can point right to the stable dchhv.org/CFP page address